### PR TITLE
Hide article request warning (from prod to repo)

### DIFF
--- a/css/custom1.css
+++ b/css/custom1.css
@@ -19,7 +19,7 @@ prm-request > div.service-form.layout-margin.layout-row > div > form > div.layou
 @media only screen
 and (min-width : 720px) {
     prm-form-field:nth-child(1) > div > md-input-container > md-radio-group > div.layout-align-start-center.layout-row:nth-child(3).md-checked::after {
-      content: 'CLS Article requests are not available; please select "Interlibrary Loan" or "Chapter/Article" requests for journal articles.';
+      content: '';
       display: block;
       position: relative;
     }


### PR DESCRIPTION
Removes the 'CLS Article requests are not available; please select "Interlibrary Loan" or "Chapter/Article" requests for journal articles' alert from the central package CSS.

This simply adds a change that's already live in the central package in Primo but hasn't yet been added to the git repository.