### PR TITLE
Hid photocopy radio button

### DIFF
--- a/css/custom1.css
+++ b/css/custom1.css
@@ -43,6 +43,13 @@ md-select[aria-label="almaResourceSharing.preferredPickupInstitution: George Was
     content: "Entry restricted to GW law affiliates";
 
 }
+
+/* Hide Photocopy option */
+md-radio-button[aria-label="Photocopy - NOT AVAILABLE"],
+md-radio-button[aria-label="Photocopy"] {
+    display: none;
+}
+
 /* End request form customizations */
 
 /* 


### PR DESCRIPTION
Sandbox and Production use different language, so I used two selectors to hide the photocopy option in both environments.